### PR TITLE
Update CI: fix coverage path variable and update ccache path

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
             TARGET_CMAKE_ARGS: "-DCMAKE_C_FLAGS='-fsanitize=thread -O2 -g -fno-omit-frame-pointer' -DCMAKE_CXX_FLAGS='-fsanitize=thread -O2 -g -fno-omit-frame-pointer'"
     env:
       ISOLATION: "shell"
-      CCACHE_DIR: ~/.ccache
+      CCACHE_DIR: /github/home/.ccache
     runs-on: ubuntu-latest
     container:
       image: ros:humble-ros-core

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,6 +51,7 @@ jobs:
         env: ${{matrix.env}}
       # Upload Coverage report if configured
       - name: Install dependency for Codecov
+        if: ${{ matrix.env.CODE_COVERAGE == 'codecov.io' }}
         run: sudo apt install curl -y
       - name: Upload coverage reports to Codecov
         if: ${{ matrix.env.CODE_COVERAGE == 'codecov.io' }}

--- a/coverage.sh
+++ b/coverage.sh
@@ -18,7 +18,7 @@ if [ "$2" = "--branch" ]; then
   branch_html_command=(--branch-coverage)
 fi
 
-package_name=${CI_PROJECT_NAME:-"rmf_scheduler"}
+package_name=${TARGET_REPO_NAME:-"rmf_scheduler"}
 
 ignored_files="*/test/*"
 


### PR DESCRIPTION
Key changes
- Update `coverage.sh` to use the TARGET_REPO_NAME variable defined by industrial_ci instead ([ref](https://github.com/ros-industrial/industrial_ci/blob/master/.github/action.sh#L27))
- Update cache path to `/github/home/ccahe`, tilda `~` doesn't seem to work here
- Disable `Install dependency for Codecov` for non-coverage workflow