### PR TITLE
Add status badges and adjust codecov color ranges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # RMF Task Scheduler
 
+[![CI](https://github.com/ros-industrial/rmf_scheduler/actions/workflows/build.yml/badge.svg?branch=main)](https://github.com/ros-industrial/rmf_scheduler/actions/workflows/build.yml)
+[![doc](https://app.readthedocs.org/projects/rmf-scheduler/badge/?version=latest)](https://app.readthedocs.org/projects/rmf-scheduler/)
+[![codecov](https://codecov.io/gh/ros-industrial/rmf_scheduler/branch/main/graph/badge.svg?token=pKmw3Ifwft)](https://codecov.io/gh/ros-industrial/rmf_scheduler)
+
 [![support level: consortium / vendor](https://img.shields.io/badge/support%20level-consortium-brightgreen.svg)](http://rosindustrial.org/news/2016/10/7/better-supporting-a-growing-ros-industrial-software-platform)
 
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,4 +1,5 @@
 coverage:
+  range: "60...80"
   status:
     project: off
     patch: off


### PR DESCRIPTION
Key changes
- Add status badges (CI, readthedocs, codecov), tagged to `main` branch
- Adjust coverage color (<60 red, 60-80 yellow, >80 green)
