### PR TITLE
Fix wrong task state update topic

### DIFF
--- a/rmf_scheduler_plugins/include/rmf_scheduler_plugins/robot_task_execution_client.hpp
+++ b/rmf_scheduler_plugins/include/rmf_scheduler_plugins/robot_task_execution_client.hpp
@@ -26,6 +26,7 @@
 #include "rmf_scheduler/schema_validator.hpp"
 
 #include "rclcpp/rclcpp.hpp"
+#include "std_msgs/msg/string.hpp"
 
 #include "rmf_task_msgs/msg/api_request.hpp"
 #include "rmf_task_msgs/msg/api_response.hpp"
@@ -67,7 +68,7 @@ private:
   void update_loop();
 
   void handle_response(
-    const rmf_task_msgs::msg::ApiResponse & response);
+    const std_msgs::msg::String & response);
 
   std::unordered_map<std::string, std::tuple<std::string, TimePoint, double>> task_status_map_;
 
@@ -75,7 +76,7 @@ private:
 
   rclcpp::Publisher<rmf_task_msgs::msg::ApiRequest>::SharedPtr pause_resume_request_publisher_;
 
-  rclcpp::Subscription<rmf_task_msgs::msg::ApiResponse>::SharedPtr task_states_sub_;
+  rclcpp::Subscription<std_msgs::msg::String>::SharedPtr task_states_sub_;
 };
 
 }  // namespace rmf_scheduler_plugins


### PR DESCRIPTION
Fixes #14 This pull request updates the `task_update` topic name and message type to match that in the `rmf_ros2` repository. After https://github.com/open-rmf/rmf_ros2/pull/383, `tasks state update`s are published to the topic via a `String` message. 